### PR TITLE
Set default shell to zsh for CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
   web:
     name: Web
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: zsh
 
     steps:
       - name: Check out repository
@@ -35,6 +38,9 @@ jobs:
   backend:
     name: API and Worker
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: zsh
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
Added default shell configuration for web and backend jobs.

## Summary

- Changed the default shell to zsh for CI actions
- We use zsh in the Makefile

## Scope

- [ ] Frontend
- [ ] API
- [ ] Worker
- [ ] Supabase / database
- [ ] Docs / policy
- [x] GitHub automation

## Verification

- [ ] `make lint-web`
- [ ] `make build-web`
- [ ] `make test-api`
- [ ] `make test-worker`
- [x] Not applicable

## Integration level

- [x] Real integration code
- [ ] Mock / scaffold only
- [ ] Mixed

## Notes

- N.A
